### PR TITLE
Fix closed target error handling logic.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build
 build:
 	cargo build
-	sudo setcap cap_net_raw=eip ${PWD}/target/debug/rsping
+	sudo setcap cap_net_raw=ep ${PWD}/target/debug/rsping
 	

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 ## Usage
 
-To use the program pass the UDP payload as utf-8 string and the target. The UDP payload can be empty.
+Pass the UDP payload as an `utf-8` string and the target to ping as arguments. The UDP payload can be empty.
 
-The target can be either and address or an hostname.
+The target can be either an address or an hostname.
 
 Both IPv4 and IPv6 are supported, hostname resolves by default to IPv6 if available.
 ```sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,8 @@ fn parse_args() -> Args {
 
 fn main() {
     let args = parse_args();
-    let loop_timeout = 2;
+    let loop_timeout = 2u32;
+    let socket_timeout = 2u32;
 
     // Create pinger.
     let timeout = if args.addr.is_ipv6() {
@@ -73,7 +74,7 @@ fn main() {
         TimeoutOption::TTL(icmp::DEFAULT_TTL)
     };
 
-    let mut pinger = Pinger::new(timeout, loop_timeout);
+    let mut pinger = Pinger::new(timeout, socket_timeout);
 
     // Setup ping loop to ping every few seconds while watching for SIGINT.
     let ticks = tick(Duration::from_secs(loop_timeout.into()));
@@ -105,7 +106,7 @@ fn main() {
                 // Wait for any any valid response.
                 match pinger.recv() {
                     Ok(r) => {
-                        if r.reply_bytes != 0 {
+                        if r.reply_bytes == 0 {
                             continue;
                         }
                         ping_recv_resp = r;

--- a/src/net/icmp.rs
+++ b/src/net/icmp.rs
@@ -1,3 +1,14 @@
+pub const ECHO_REQUEST4_TYPE: u8 = 8;
+pub const ECHO_REQUEST4_CODE: u8 = 0;
+pub const ECHO_REQUEST6_TYPE: u8 = 128;
+pub const ECHO_REQUEST6_CODE: u8 = 0;
+pub const ECHO_REQUEST_PORT: u8 = 0;
+
+pub const PACKET_SIZE: usize = 64;
+
+pub const DEFAULT_TTL: u32 = 64;
+pub const DEFAULT_HOPS: u32 = 3;
+
 pub enum IcmpProto {
     V4,
     V6,
@@ -65,16 +76,6 @@ fn calculate_checksum(buf: &[u8]) -> u16 {
     let sum = !sum as u16;
     sum
 }
-
-pub const ECHO_REQUEST4_TYPE: u8 = 8;
-pub const ECHO_REQUEST4_CODE: u8 = 0;
-pub const ECHO_REQUEST6_TYPE: u8 = 128;
-pub const ECHO_REQUEST6_CODE: u8 = 0;
-pub const ECHO_REQUEST_PORT: u8 = 0;
-
-pub const PACKET_SIZE: usize = 64;
-pub const TTL: u32 = 64;
-pub const HOPS: u8 = 3;
 
 pub enum EchoRequestPacket {
     V4(Echo4RequestPacket),

--- a/src/ping/errors.rs
+++ b/src/ping/errors.rs
@@ -1,4 +1,4 @@
-use std::{error, fmt};
+use std::fmt;
 
 #[derive(Debug, Clone)]
 pub enum PingRecvErrs {
@@ -12,8 +12,6 @@ impl fmt::Display for PingRecvErrs {
         }
     }
 }
-
-impl error::Error for PingRecvErrs {}
 
 #[derive(Debug, Clone)]
 pub enum PingErrors {
@@ -35,5 +33,3 @@ impl fmt::Display for PingSendError {
         }
     }
 }
-
-impl error::Error for PingSendError {}


### PR DESCRIPTION
This PR fixes the behaviour when pinging closed targets. It should now mimic ping's behaviour of not displaying output for these cases. Also has misc fixes.